### PR TITLE
Fixes for Issues #28 and #29

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -67,7 +67,10 @@ function install(data, reason)
 
 function uninstall(data, reason) 
 {
-    removeUserPrefs();
+    if(ADDON_UNINSTALL === reason)
+    {
+        removeUserPrefs();
+    }
 }
 
 function loadIntoWindow(window) 
@@ -106,7 +109,7 @@ function unloadFromWindow(window)
 
 function forEachOpenWindow(applyThisFunc)
 {
-    PersonaSwitcher.allWindows(applyThisFunc);
+    PersonaSwitcher.allWindows(applyThisFunc);    
 }
 
 var WindowListener = 
@@ -171,6 +174,9 @@ function messageHandler(message, sender, sendResponse)
             // true to indicate we are going to send a response.
             // http://stackoverflow.com/questions/40772929/promise-from-browser-runtime-sendmessage-fulfilling-prior-to-asynchronous-call
             return true;
+            break;
+        case "Return-All-Prefs":
+            sendResponse(getAllPrefs());
             break;
         case "Switch-Themes":
             PersonaSwitcher.switchTo(message.theme, message.index);
@@ -394,6 +400,48 @@ function setPreference(preference, value)
             PersonaSwitcher.prefs.setBoolPref("debug", value);
             break;
     }
+}
+
+function getAllPrefs()
+{
+    var userPreferences = [
+    "defshift", "defcontrol", "defalt", "defmeta", "defaccel", "defos", 
+    "defkey", "rotshift", "rotcontrol", "rotalt", "rotmeta", "rotaccel", 
+    "rotos", "rotkey", "autoshift", "autocontrol", "autoalt", "autometa", 
+    "autoaccel", "autoos", "autokey", "activateshift", "activatecontrol", 
+    "activatealt", "activatemeta", "activateaccel", "activateos", "activatekey",
+    "toolsshift", "toolscontrol", "toolsalt", "toolsmeta", "toolsaccel",
+    "toolsos", "toolskey", "accesskey", "auto", "autominutes", "random", 
+    "preview", "preview-delay", "icon-preview", "tools-submenu", 
+    "main-menubar", "debug", "notification-workaround", 
+    "toolbox-minheight", "startup-switch", "fastswitch", "current"];
+
+    var prefType;
+    var prefValue;
+    var prefsObj = {};
+    for(var pref of userPreferences) 
+    {
+        prefType = PersonaSwitcher.prefs.getPrefType(pref);
+        switch(prefType) 
+        {
+            case PersonaSwitcher.prefs.PREF_STRING:
+                prefValue = PersonaSwitcher.prefs.getCharPref(pref);
+                break;
+            case PersonaSwitcher.prefs.PREF_INT:
+                prefValue = PersonaSwitcher.prefs.getIntPref(pref).toString();
+                break;
+            case PersonaSwitcher.prefs.PREF_BOOL:
+                prefValue = PersonaSwitcher.prefs.getBoolPref(pref).toString();
+                break;
+            case PersonaSwitcher.prefs.PREF_INVALID:
+            default:
+                continue;
+        }
+
+        prefsObj[pref] = prefValue;
+    }
+
+    return prefsObj;  
 }
 
 // UI Injection

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -648,14 +648,10 @@ PersonaSwitcher.onWindowLoad = function (doc)
     }
     else
     {
-        // we already should have the default theme at this point, crosses
-        // fingers
+        // We already should have the default theme at this point, crosses
+        // fingers. We also should have set the theme already when the first
+        // window was opened so we do not switch to the current theme here.
         PersonaSwitcher.createStaticPopups(doc);
-        PersonaSwitcher.currentIndex =
-            PersonaSwitcher.prefs.getIntPref ("current");
-        PersonaSwitcher.switchTo(
-            PersonaSwitcher.currentThemes[PersonaSwitcher.currentIndex],
-            PersonaSwitcher.currentIndex);
     }
 
     PersonaSwitcher.setKeyset (doc);

--- a/webextension/background_scripts/WEPersonaSwitcher.js
+++ b/webextension/background_scripts/WEPersonaSwitcher.js
@@ -32,75 +32,142 @@ function loadDefaultsIfNeeded(prefs)
 
 function loadDefaults()
 {
-    var setting = browser.storage.local.set(
+    var getLegacyPrefs = browser.runtime.sendMessage({command: "Return-All-Prefs"});
+
+    return getLegacyPrefs
+        .then(function(prefs) 
         {
-            defaults_loaded: true,
+            return Promise.resolve(buildPrefsStorageArg(prefs));            
+        })
+        .then(function(prefsStorageArg)
+        {
+            browser.storage.local.set(prefsStorageArg).then(
+                function() 
+                { 
+                    return Promise.resolve();
+                });
+        });        
+}
 
-            defaultKeyShift: false,
-            defaultKeyControl: true,
-            defaultKeyAlt: true,
-            defaultKeyMeta: false,
-            defaultKeyAccel: false,
-            defaultKeyOS: false,
-            defaultKey: "D",
+function buildPrefsStorageArg(prefs) 
+{
+    // The arrays hold the keys for the preferences in the bootstrap addon,
+    // the WebExtension, and the default values for the preferences. 
+    // The index for a particular preference MUST be kept consistent between
+    // all three arrays.
+    var prefKeyOld = [
+        "defshift", "defcontrol", "defalt", "defmeta", "defaccel", "defos",
+        "defkey", "rotshift", "rotcontrol", "rotalt", "rotmeta", "rotaccel",
+        "rotos", "rotkey", "autoshift", "autocontrol", "autoalt", "autometa",
+        "autoaccel", "autoos", "autokey", "activateshift", "activatecontrol",
+        "activatealt", "activatemeta", "activateaccel", "activateos",
+        "activatekey", "toolsshift", "toolscontrol", "toolsalt", "toolsmeta",
+        "toolsaccel", "toolsos", "toolskey", "accesskey", "auto", "autominutes",
+        "random", "preview", "preview-delay", "icon-preview", "tools-submenu",
+        "main-menubar", "debug", "toolbox-minheight", "startup-switch",
+        "fastswitch", "current"];
 
-            rotateKeyShift: false,
-            rotateKeyControl: true,
-            rotateKeyAlt: true,
-            rotateKeyMeta: false,
-            rotateKeyAccel: false,
-            rotateKeyOS: false,
-            rotateKey: "R",
+    var prefKeyWE = [
+        "defaultKeyShift", "defaultKeyControl", "defaultKeyAlt",
+        "defaultKeyMeta", "defaultKeyAccel", "defaultKeyOS", "defaultKey",
+        "rotateKeyShift", "rotateKeyControl", "rotateKeyAlt", "rotateKeyMeta",
+        "rotateKeyAccel", "rotateKeyOS", "rotateKey", "autoKeyShift",
+        "autoKeyControl", "autoKeyAlt", "autoKeyMeta", "autoKeyAccel",
+        "autoKeyOS", "autoKey", "activateKeyShift", "activateKeyControl",
+        "activateKeyAlt", "activateKeyMeta", "activateKeyAccel",
+        "activateKeyOs", "activateKey", "toolsKeyShift", "toolsKeyControl",
+        "toolsKeyAlt", "toolsKeyMeta", "toolsKeyAccel", "toolsKeyOs",
+        "toolsKey", "accessKey", "auto", "autoMinutes", "random", "preview",
+        "previewDelay", "iconPreview", "toolsMenu", "mainMenuBar", "debug",
+        "toolboxMinHeight", "startupSwitch", "fastSwitch", "current"];
 
-            autoKeyShift: false,
-            autoKeyControl: true,
-            autoKeyAlt: true,
-            autoKeyMeta: false,
-            autoKeyAccel: false,
-            autoKeyOS: false,
-            autoKey: "A",
+    var defaultVals = [
+        'false', 'true', 'true', 'false', 'false', 'false', 'D',
+        'false', 'true', 'true', 'false', 'false', 'false', 'R',
+        'false', 'true', 'true', 'false', 'false', 'false', 'A',
+        'false', 'true', 'true', 'false', 'false', 'false', 'P',
+        'false', 'true', 'true', 'false', 'false', 'false', 'M',
+        'P', 'false', '30', 'false', 'false', '0', 'true', 'true',
+        'false', 'false', '0', 'false', 'false', '0'];
 
-            accessKey: "P",
 
-            activateKeyShift: false,
-            activateKeyControl: true,
-            activateKeyAlt: true,
-            activateKeyMeta: false,
-            activateKeyAccel: false,
-            activateKeyOs: false,
-            activateKey: "P",
-            
-            toolsKeyShift: false,
-            toolsKeyControl: true,
-            toolsKeyAlt: true,
-            toolsKeyMeta: false,
-            toolsKeyAccel: false,
-            toolsKeyOs: false,
-            toolsKey: "M",
+    var prefsStorageArg = {};
+    // WebExtension only preferences are simply set to the default values.
+    prefsStorageArg['toolboxMaxHeight'] = 200;
+    prefsStorageArg['defaults_loaded'] = true;
 
-            auto: false,
-            autoMinutes: 30,
-            random: false,
-            startupSwitch: false,
-            preview: false,
-            previewDelay: 0,
-            iconPreview: true,
-            toolboxMinHeight: 0,
-            toolsMenu: true,
-            mainMenuBar: false,
-            debug: false,
-            fastSwitch: false,
-            toolboxMaxHeight: 200,
+    // All other preferences are assigned either the value present in the 
+    // equivalent legacy preference or the default value if no existing value
+    // could be found.
+    for(let index = 0; index < prefKeyWE.length; index++)
+    {
+        var oldValue = prefs[prefKeyOld[index]];
+        var valueToStore = 
+            (null === oldValue || 'undefined' === typeof(oldValue)) 
+                ? defaultVals[index] : oldValue;
 
-            // hidden preferences
-            current: 0
-        });
-    return setting.then(
-        function() 
-        { 
-            return Promise.resolve();
-        }, 
-        handleError);
+        switch(prefKeyWE[index])
+        {
+            case 'defaultKeyShift':
+            case 'defaultKeyControl':
+            case 'defaultKeyAlt':
+            case 'defaultKeyMeta':
+            case 'defaultKeyAccel':
+            case 'defaultKeyOS':
+            case 'rotateKeyShift':
+            case 'rotateKeyControl':
+            case 'rotateKeyAlt':
+            case 'rotateKeyMeta':
+            case 'rotateKeyAccel':
+            case 'rotateKeyOS':
+            case 'autoKeyShift':
+            case 'autoKeyControl':
+            case 'autoKeyAlt':
+            case 'autoKeyMeta':
+            case 'autoKeyAccel':
+            case 'autoKeyOS':
+            case 'activateKeyShift':
+            case 'activateKeyControl':
+            case 'activateKeyAlt':
+            case 'activateKeyMeta':
+            case 'activateKeyAccel':
+            case 'activateKeyOs':            
+            case 'toolsKeyShift':
+            case 'toolsKeyControl':
+            case 'toolsKeyAlt':
+            case 'toolsKeyMeta':
+            case 'toolsKeyAccel':
+            case 'toolsKeyOs':
+            case 'auto':
+            case 'random':
+            case 'startupSwitch':
+            case 'preview':
+            case 'iconPreview':
+            case 'toolsMenu':
+            case 'mainMenuBar':
+            case 'debug':
+            case 'fastSwitch':
+                prefsStorageArg[prefKeyWE[index]] = (valueToStore === 'true');
+                break;
+            case 'toolsKey':
+            case 'activateKey':
+            case 'accessKey':
+            case 'autoKey':
+            case 'rotateKey':
+            case 'defaultKey':
+                prefsStorageArg[prefKeyWE[index]] = valueToStore;
+                break;
+            case 'autoMinutes':
+            case 'previewDelay':
+            case 'toolboxMinHeight':
+            case 'toolboxMaxHeight':
+            case 'current':
+                prefsStorageArg[prefKeyWE[index]] = parseInt(valueToStore);
+                break;
+        }
+    }
+
+    return prefsStorageArg;
 }
 
 function getMenuData() 

--- a/webextension/background_scripts/WEPersonaSwitcher.js
+++ b/webextension/background_scripts/WEPersonaSwitcher.js
@@ -541,7 +541,7 @@ browser.contextMenus.onClicked.addListener((info) =>
         browser.runtime.openOptionsPage(); 
     });
 
-var logger;
+var logger = console;
 var nullLogger = {};
 nullLogger.log = function (s) 
 { 
@@ -567,7 +567,7 @@ function setLogger()
 
 function handleError(error) 
 {
-    logger.log(`Error: ${error}`);
+    logger.log(`${error}`);
 }
 
 handleStartup();


### PR DESCRIPTION
### Preference Retention on Upgrade
Added legacy preference retrieval on first run for the embedded WebExtension. Preferences should now be retained when upgrading. This *should* solve issue #28.

**Note:** Because this solution relies on the ability of overlay/bootstrap addons to access Firefox preferences, this will only continue to work while the WebExtension remains embedded. Once all functionality is migrated and the embedding bootstrap addon is removed, this solution will no longer work and a new solution will have to be found. (Using Window.localStorage or Window.sessionStorage does not seem to be a viable alternative at this point as neither seemed to be available in the most recent Firefox. Tested using the method outlined here: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Feature-detecting_localStorage)

### Switching Theme to Current

Restricted the setting of the theme to the current theme to happen only when the first window is opened. Subsequent newly opened windows assume that the theme has already been set to the current theme. This addresses issue #29.