### PR TITLE
Dev/web extension

### DIFF
--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -315,30 +315,7 @@ PersonaSwitcher.themeMonitor = function()
     }
     catch (e1)
     {
-    // http://mxr.mozilla.org/firefox/source/toolkit/mozapps/extensions/public/nsIExtensionManager.idl
-    // http://www.oxymoronical.com/experiments/apidocs/interface/nsIExtensionManager
-    // http://www.oxymoronical.com/experiments/apidocs/interface/nsIAddonInstallListener
-    // https://github.com/ehsan/mozilla-cvs-history/blob/master/toolkit/mozapps/extensions/public/nsIExtensionManager.idl
-
-    // 550   const unsigned long TYPE_THEME = 0x04;
-    // 559   readonly attribute long type;
-
-    // can we pretend add-ons aren't removed until reboot because there is no
-    // listener?
-        PersonaSwitcher.logger.log ('trying ExtensionManager');
-        try
-        {
-            PersonaSwitcher.extensionManager =
-                Components.classes['@mozilla.org/extensions/manager;1'].
-                    getService(Components.interfaces.nsIExtensionManager);
-            PersonaSwitcher.logger.log ('using ExtensionManager');
-            PersonaSwitcher.extensionManager.
-                addInstallListener(PersonaSwitcher.ExtensionListener);
-        }
-        catch (e2)
-        {
-            PersonaSwitcher.logger.log ('completely failed');
-        }
+        PersonaSwitcher.logger.log ('completely failed to load addonManager');
     }
 };
 

--- a/chrome/content/ui.js
+++ b/chrome/content/ui.js
@@ -562,7 +562,7 @@ PersonaSwitcher.removeStaticPopups = function (doc)
         // not all windows have this popup
         if (item)
         {
-            item.setAttribute ('onpopupshowing',
+            item.addEventListener ('popupshowing',
                 'PersonaSwitcher.createMenuPopup (event);');
         }
     }

--- a/chrome/locale/zh-CN/personaswitcher.properties
+++ b/chrome/locale/zh-CN/personaswitcher.properties
@@ -1,2 +1,2 @@
 personaswitcher.noPersonas=找不到面板
-personaswitcher-button.label=面板
+personaswitcher-menu.label=面板

--- a/chrome/locale/zh-TW/personaswitcher.properties
+++ b/chrome/locale/zh-TW/personaswitcher.properties
@@ -1,2 +1,2 @@
 ﻿personaswitcher.noPersonas=找不到面板
-personaswitcher-button.label=面板
+personaswitcher-menu.label=面板

--- a/webextension/background_scripts/WEPersonaSwitcher.js
+++ b/webextension/background_scripts/WEPersonaSwitcher.js
@@ -224,10 +224,10 @@ function buildMenuItem(theme, prefs, theIndex)
 
     if (true === prefs.preview) 
     {
-        themeChoice.addEventListener('mouseover',
-                        mouseOverListener(theme, prefs.previewDelay));
-        themeChoice.addEventListener('mouseout',
-                        mouseOutListener(theme, prefs.preview));
+        themeChoice.addEventListener('mouseenter',
+                        mouseEnterListener(theme, prefs.previewDelay));
+        themeChoice.addEventListener('mouseleave',
+                        mouseLeaveListener(theme, prefs.preview));
     }
     themeChoice.addEventListener('click', clickListener(theme, theIndex));
     return themeChoice;
@@ -274,7 +274,7 @@ var clickListener = function(theTheme, theIndex)
 };
 
 var previewAlarmListener;
-var mouseOverListener = function(theTheme, previewDelay) 
+var mouseEnterListener = function(theTheme, previewDelay) 
 {
     const MS_TO_MINUTE_CONVERSION = 60000;
     return function() 
@@ -295,7 +295,7 @@ var mouseOverListener = function(theTheme, previewDelay)
     };
 };
 
-var mouseOutListener = function(theTheme) 
+var mouseLeaveListener = function(theTheme) 
 { 
     return function() 
     { 

--- a/webextension/preferences/options.js
+++ b/webextension/preferences/options.js
@@ -229,13 +229,14 @@ function onError(error)
     console.log(`Error: ${error}`);
 }
 
+// https://developer.mozilla.org/en-US/docs/Displaying_web_content_in_an_extension_without_security_issues
 function localizeHtmlPage()
 {
     var objects = document.getElementsByName("i18n");
     for (var j = 0; j < objects.length; j++)
     {    
         var obj = objects[j];
-        obj.innerHTML = browser.i18n.getMessage(obj.id.toString());
+        obj.textContent = browser.i18n.getMessage(obj.id.toString());
     }
 }
 
@@ -258,7 +259,7 @@ function updateMaxHeight(value)
 {
         toolboxMinHeightObject.max = value;
         var maxHeightHintObject = document.getElementById("maxHeight");
-        maxHeightHintObject.innerHTML = toolboxMinHeightObject.max;
+        maxHeightHintObject.textContent = toolboxMinHeightObject.max;
 }
 
 function updateToolsMenuShortcutDisplay()


### PR DESCRIPTION
### <div align="center">Updates to Facilitate Validation</div>
#### Validation Warnings:
#### Mouse events may cause performance issues.
Updated these to listen for the mouseenter and mouseleave events as the validation message states, "The use of `mousemove`, `mouseover`, and `mouseout` is discouraged. These events are dispatched with high frequency and can cause severe performance issues."

#### Reference to critical user proﬁle data
This warning is unavoidable. As far as I can tell there is no API that allows bootstrap addons to have default preferences. The following discussion on the Mozilla addon boards suggests simply including a note to the review team about the issue. (note: the post is partway down the discussion) [discussion post](https://discourse.mozilla-community.org/t/banned-element-in-install-rdf-error-when-validating-extension/4578/5)

#### on* attribute being set using setAttribute
Changed one instance of setting up an event listener to use the suggested addEventListener function. 
HOWEVER: Keys seem to behave differently and will not function without the setAttribute being called. Because of this, the setAttribute is assigned a void function and the actual event listener is setup using the addEventListener function. A discussion of this issue can be found [here](http://stackoverflow.com/questions/16779316/how-to-set-an-xul-key-dynamically-and-securely). This may also need to be communicated to the reviewers.

#### Obsolete Extension Manager API and Access to the `getService` global
In order to be compatible with the validation tool, the backup attempt to load nsIExtensionManage, which would be attempted if the addonManager failed to load, was removed. The code will now simply fail if the addonManager cannot load.

#### Markup should not be passed to `innerHTML` dynamically.
In order to be compatible with the validation tool, changed the internationalization of the html of the preferences page to be done using textContent instead of innerHTML as suggested [here](https://developer.mozilla.org/en-US/docs/Displaying_web_content_in_an_extension_without_security_issues).

#### Missing translation entity
Both of the Chinese dialects' internationalization files were updated to have the personaswitcher-menu.label entry instead of personaswitcher-button.label. The warning that the personaswitcher.noPersonas entry was missing in the zh-TW file appears to have been a mistake as it appears to be present and identical to the other file.